### PR TITLE
Initial RegisterSet Implementation

### DIFF
--- a/app/js/lib/lc3/core/registerset.js
+++ b/app/js/lib/lc3/core/registerset.js
@@ -1,5 +1,7 @@
 function RegisterSet(num_gpr) {
-  if(num_gpr > 8 || num_gpr < 0) {
+  if(num_gpr === undefined) {
+    num_gpr = 8
+  } else if(num_gpr > 8 || num_gpr < 0) {
     return null;
   }
 

--- a/app/js/lib/lc3/core/registerset.js
+++ b/app/js/lib/lc3/core/registerset.js
@@ -1,0 +1,91 @@
+function RegisterSet(num_gpr) {
+  if(num_gpr > 8 || num_gpr < 0) {
+    return null;
+  }
+
+  if(!(this instanceof RegisterSet)) {
+    return new RegisterSet(num_gpr);
+  }
+
+  this.gp_reg_count = num_gpr;
+
+  this.register_data = new Uint16Array(
+    this.sys_reg_count +
+    this.io_reg_count +
+    this.gp_reg_count
+  );
+
+  // Initialize GPRs.
+  let idx = this.gpr_offset, reg = 0;
+  while(num_gpr-- > 0) {
+    this.register_data[
+      this.register_map["R" + (reg++).toString()] = idx++ // map name to index
+    ] = 0; // initialize value at index to zero
+  }
+}
+
+RegisterSet.prototype.register_map = {
+  // System registers.
+  "PC": 0,
+  "IR": 1,
+  "CC": 2,
+
+  // I/O registers.
+  "KBSR": 3,
+  "KBDR": 4,
+  "DSR":  5,
+  "DDR":  6,
+  "MCR":  7,
+};
+
+RegisterSet.prototype.sys_reg_count = 3; // PC, IR, CC
+RegisterSet.prototype.io_reg_count = 5; // see table A.3
+RegisterSet.prototype.gp_reg_count = 0;
+
+// Index of first GPR in register_data.
+RegisterSet.prototype.gpr_offset = RegisterSet.prototype.sys_reg_count +
+                                   RegisterSet.prototype.io_reg_count;
+
+// Returns index mapped to by register or null if invalid register name.
+RegisterSet.prototype.lookup = function(reg) {
+  if(typeof reg === "number" && reg < this.gp_reg_count && reg >= 0) {
+    return this.gpr_offset + reg;
+  }
+  if(typeof reg === "string" && reg in this.register_map) {
+    return this.register_map[reg];
+  }
+  return null;
+};
+
+// Returns value stored in register or null if invalid register name.
+RegisterSet.prototype.get = function(reg) {
+  let r = this.lookup(reg);
+  if(r != null) {
+    return this.register_data[r];
+  }
+  return null;
+};
+
+RegisterSet.prototype.set = function(reg, val) {
+  let r = this.lookup(reg);
+  if(r != null) {
+    this.register_data[r] = val;
+  }
+};
+
+// Returns a closure that returns the value of a predetermined register.
+RegisterSet.prototype.getter = function(reg) {
+  let that = this;
+  return function() {
+    return that.get(reg);
+  };
+};
+
+// Returns a closure that can be called with an argument to set the value of a
+// predetermined register to said argument.
+RegisterSet.prototype.setter = function(reg) {
+  let that = this;
+  return function(val) {
+    that.set(reg, val);
+  };
+};


### PR DESCRIPTION
This pull request serves as a proposal for an architecture regarding register management.

This proposal defines a RegisterSet class to manage register state, access, and modification and architecture flexibility.

RegisterSet Features
---
Create instances with 0 - 8 general purpose registers.
```
let regset1 = new RegisterSet(8), // 8 GPRs
    regset2 = new RegisterSet(),  // also 8 GPRs
    regset3 = new RegisterSet(4); // 4 GPRs
```
Access registers by string name...
```
let r3 = regset.get("R3"),
    pc = regset.get("PC");
```
...or GPR number.
```
let r5 = regset.get(5),
    r0 = regset.get(0);
```
Generate register-specific closures that get/set values of a predetermined register.
```
let r5g = regset.getter(5), // or regset.getter("R5")
    r5s = regset.setter(5);
```
```
> r5s(0xffff);
> r5g();
65535
> r5s(0);
> r5g();
0
```

Future Proof Design
---
Having a mapping from register names to register data will allow for a clean handling of the stack pointer changing based on permissions. This implementation does not have stack pointer functionality but was designed with it in mind.

While not a design goal directly, registers can be added on the fly simply by extending (redefining, worst case) `register_data` and adding an entry to `register_map`.

Considerations
---
Depending on how fancy we plan on getting with architecture flexibility, we could have the RegisterSet constructor take a config object of sorts as its argument.

Especially if adding registers on the fly is of interest, it might be better to always allocate enough space in `register_data` to handle 8 GPRs. The maximum is steadfast as per LC-3's definition, and, resource-wise, the difference between 0-7 GPRs and 8 GPRs is not that significant.