### PR TITLE
refactored to match style of registerset.js

### DIFF
--- a/app/js/lib/lc3/core/subroutines.js
+++ b/app/js/lib/lc3/core/subroutines.js
@@ -1,88 +1,89 @@
+function Subroutines() {
+  const add = function (inst) {
+    // TODO
+  }
 
-const add = function (inst) {
-  // TODO
+  const and = function (inst) {
+    // TODO
+  }
+
+  const not = function (inst) {
+    // TODO
+  }
+
+  const br = function (inst) {
+    // TODO
+  }
+
+  const st = function (inst) {
+    // TODO
+  }
+
+  const ld = function (inst) {
+    // TODO
+  }
+
+  const str = function (inst) {
+    // TODO
+  }
+
+  const ldr = function (inst) {
+    // TODO
+  }
+
+  const jmp = function (inst) {
+    // TODO
+  }
+
+  const jsr = function (inst) {
+    // TODO
+  }
+
+  const ldi = function (inst) {
+    // TODO
+  }
+
+  const sti = function (inst) {
+    // TODO
+  }
+
+  const lea = function (inst) {
+    // TODO
+  }
+
+  const trap = function (inst) {
+    // TODO
+  }
+
+  const rti = function (inst) {
+    // TODO
+  }
+
+  const reserved = function (inst) {
+    // TODO
+  }
+
+  const subroutines = {
+    0x1: add,
+    0x5: and,
+    0x9: not,
+    0x0: br,
+    0x3: st,
+    0x2: ld,
+    0x7: str,
+    0x6: ldr,
+    0xC: jmp,
+    0x4: jsr,
+    0xA: ldi,
+    0xB: sti,
+    0xE: lea,
+    0xF: trap,
+    0x8: rti,
+    0xD: reserved
+  }
 }
 
-const and = function (inst) {
-  // TODO
-}
-
-const not = function (inst) {
-  // TODO
-}
-
-const br = function (inst) {
-  // TODO
-}
-
-const st = function (inst) {
-  // TODO
-}
-
-const ld = function (inst) {
-  // TODO
-}
-
-const str = function (inst) {
-  // TODO
-}
-
-const ldr = function (inst) {
-  // TODO
-}
-
-const jmp = function (inst) {
-  // TODO
-}
-
-const jsr = function (inst) {
-  // TODO
-}
-
-const ldi = function (inst) {
-  // TODO
-}
-
-const sti = function (inst) {
-  // TODO
-}
-
-const lea = function (inst) {
-  // TODO
-}
-
-const trap = function (inst) {
-  // TODO
-}
-
-const rti = function (inst) {
-  // TODO
-}
-
-const reserved = function (inst) {
-  // TODO
-}
-
-var subroutines = {
-  0x1: add,
-  0x5: and,
-  0x9: not,
-  0x0: br,
-  0x3: st,
-  0x2: ld,
-  0x7: str,
-  0x6: ldr,
-  0xC: jmp,
-  0x4: jsr,
-  0xA: ldi,
-  0xB: sti,
-  0xE: lea,
-  0xF: trap,
-  0x8: rti,
-  0xD: reserved
-}
-
-function execute(bytes) {
+Subroutines.prototype.execute = function(bytes) {
   const opcode = bytes >> 12;
   subroutines[opcode](bytes);
-}
+};


### PR DESCRIPTION
This pull request serves as a proposal for refactoring subroutines.js - the component responsible for executing binary code.

This proposal defines a Subroutines class to hold the private opcode emulator functions along with the public method execute, which takes a 16 bit input and executes it.

Subroutines Features
---
Create instances with no parameters
```
let subr = new Subroutines();
```
Execute binary...
```
let subr = new Subroutines();
subr.execute(0x32D3);
```

Class structure / hierarchy - where do we go from here? 
---

JavaScript has changed a lot over the years, and as such, I have gathered a lot technical debt with the language. I don't think this current implementation is sufficient for our use case. I think I need to read up on how we can export/ import in JS similar to that of how it's done in Python.

LC3 needs an instance of RegisterSet, and and instance of Subroutines. Subroutines needs to be able to access RegisterSet. We also still have some class / data structure hold the rest of memory. These things should be addressed in a future PR (wiring things up, so to speak).